### PR TITLE
Fix line color config overriding user autocmds

### DIFF
--- a/plugin/ale-sensible.vim
+++ b/plugin/ale-sensible.vim
@@ -26,7 +26,7 @@ let g:ale_lint_delay = 0
 
 " Set gorgeous colors for marked lines to sane, readable combinations 
 " working with any colorscheme
-au! VimEnter,BufEnter,ColorScheme *
+au VimEnter,BufEnter,ColorScheme *
   \ exec "hi! ALEInfoLine
     \ guifg=".(&background=='light'?'#808000':'#ffff00')."
     \ guibg=".(&background=='light'?'#ffff00':'#555500') |


### PR DESCRIPTION
Overriding (instead of appending to) all autocommands for VimEnter,BufEnter breaks a lot of plugins and user configurations, and line coloring still seems to work after removing the bang, so this patch does that.